### PR TITLE
Add Data ONE to expected data centers

### DIFF
--- a/src/conf/acadis/appConfig-integration.js
+++ b/src/conf/acadis/appConfig-integration.js
@@ -135,6 +135,10 @@ define([],
             shortName: 'R2R',
             longName: 'Rolling Deck to Repository',
             url: 'http://rvdata.us/about/technical'
+          }, {
+            shortName: 'Data ONE',
+            longName: 'Data Observation Network for Earth',
+            url: 'https://www.dataone.org'
           }
         ]
 

--- a/src/conf/acadis/appConfig-production.js
+++ b/src/conf/acadis/appConfig-production.js
@@ -135,6 +135,10 @@ define([],
             shortName: 'R2R',
             longName: 'Rolling Deck to Repository',
             url: 'http://rvdata.us/about/technical'
+          }, {
+            shortName: 'Data ONE',
+            longName: 'Data Observation Network for Earth',
+            url: 'https://www.dataone.org'
           }
         ]
 

--- a/src/conf/acadis/appConfig-qa.js
+++ b/src/conf/acadis/appConfig-qa.js
@@ -135,6 +135,10 @@ define([],
             shortName: 'R2R',
             longName: 'Rolling Deck to Repository',
             url: 'http://rvdata.us/about/technical'
+          }, {
+            shortName: 'Data ONE',
+            longName: 'Data Observation Network for Earth',
+            url: 'https://www.dataone.org'
           }
         ]
 


### PR DESCRIPTION
When the search-solr-tools work is complete, this change will be necessary for a count of DataONE results to be visible on the ADE home page.

https://www.pivotaltracker.com/story/show/77763710
https://github.com/nsidc/search-solr-tools/pull/6

@Jkovarik 