### PR TITLE
Use different versions of OpenLayers for ADE/NSIDC Search

### DIFF
--- a/src/templates/acadis-index.jade
+++ b/src/templates/acadis-index.jade
@@ -1,5 +1,8 @@
 extends index-layout
 
+block project-openlayers
+  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
+
 block project-css
   link(rel='canonical',href='http://www.nsidc.org/acadis/search/')
   link(href='css/acadis-search.css',rel='stylesheet',type='text/css')

--- a/src/templates/index-layout.jade
+++ b/src/templates/index-layout.jade
@@ -13,7 +13,9 @@ html
     block project-css
 
     script(src='https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js')
-    script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
+
+    block project-openlayers
+
     script(src='contrib/proj4js/proj4js-1.1.0-compressed.js')
     script(src='https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js')
     script(src='https://cdnjs.cloudflare.com/ajax/libs/underscore.string/2.3.0/underscore.string.min.js')

--- a/src/templates/nsidc-index.jade
+++ b/src/templates/nsidc-index.jade
@@ -1,5 +1,8 @@
 extends index-layout
 
+block project-openlayers
+  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.12/OpenLayers.min.js')
+
 block project-css
   link(rel='canonical',href='http://www.nsidc.org/data/search/')
   link(href='css/nsidc-search.css',rel='stylesheet',type='text/css')


### PR DESCRIPTION
The OpenLayers upgrade is causing a strange issue for NSIDC Search where
the home page only has the search terms field; the spatial and temporal
fields are not rendered, nor is the "Data Sets for Researchers"
description text.

We wanted to upgrade OpenLayers for the ADE to fix the mouseover
coordinate issue (which is still present in NSIDC Search), so make the
different apps use different versions of OpenLayers.

@Jkovarik 