### PR TITLE
Fixed NSIDC Search map with strange character in coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+Bug fixes
+
+- Update dependency OpenLayers; this fixes the display string in the lower righthand
+  corner of the map showing the coordinates of the cursor.  (NSIDC Search)
+
 ## 1.10.0 (2015-09-25)
 
 New Features
@@ -12,7 +19,7 @@ Bugfixes
 
 - Fix display of coordinates of the selected bounding box over HTTPS.
 - Update dependency OpenLayers; this fixes the display string in lower righthand
-  corner of map showing the coordinates of the cursor.
+  corner of map showing the coordinates of the cursor.  (ACADIS)
 
 ## 1.9.0 (2015-07-01)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,6 +77,9 @@ from `src/conf/`.
 
 ## Running the app locally
 
+Make sure grunt is installed by running `npm install -g grunt-cli` (with root
+access).
+
 Run `grunt build:nsidc-dev` or `grunt build:acadis-dev` to generate the
 appropriate `src/index.html` file (as well as css files), then
 `./run_local_webserver.rb` and open your browser to http://localhost:8081.

--- a/src/scripts/lib/OpenLayerMap.js
+++ b/src/scripts/lib/OpenLayerMap.js
@@ -992,6 +992,7 @@ define(['lib/mediator_mixin',
       maxExtent: SpatialSelectionUtilities.MAP_SETTINGS[newSrid].extent,
       maxResolution: mapMaxResolution,
       tileSize: new OpenLayers.Size(mapWidth, mapHeight),
+      size: new OpenLayers.Size(mapWidth, mapHeight),
       numZoomLevels: SpatialSelectionUtilities.MAP_SETTINGS[newSrid].numZoomLevels,
       controls: [] // Disable default controls
     };

--- a/src/templates/acadis-index.jade
+++ b/src/templates/acadis-index.jade
@@ -1,8 +1,5 @@
 extends index-layout
 
-block project-openlayers
-  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
-
 block project-css
   link(rel='canonical',href='http://www.nsidc.org/acadis/search/')
   link(href='css/acadis-search.css',rel='stylesheet',type='text/css')

--- a/src/templates/index-layout.jade
+++ b/src/templates/index-layout.jade
@@ -14,8 +14,7 @@ html
 
     script(src='https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js')
 
-    block project-openlayers
-      script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
+    script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
 
     script(src='contrib/proj4js/proj4js-1.1.0-compressed.js')
     script(src='https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js')

--- a/src/templates/index-layout.jade
+++ b/src/templates/index-layout.jade
@@ -15,6 +15,7 @@ html
     script(src='https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.0/jquery.min.js')
 
     block project-openlayers
+      script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
 
     script(src='contrib/proj4js/proj4js-1.1.0-compressed.js')
     script(src='https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js')

--- a/src/templates/nsidc-index.jade
+++ b/src/templates/nsidc-index.jade
@@ -1,7 +1,7 @@
 extends index-layout
 
 block project-openlayers
-  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.12/OpenLayers.min.js')
+  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
 
 block project-css
   link(rel='canonical',href='http://www.nsidc.org/data/search/')

--- a/src/templates/nsidc-index.jade
+++ b/src/templates/nsidc-index.jade
@@ -1,8 +1,5 @@
 extends index-layout
 
-block project-openlayers
-  script(src='https://cdnjs.cloudflare.com/ajax/libs/openlayers/2.13.1/OpenLayers.js')
-
 block project-css
   link(rel='canonical',href='http://www.nsidc.org/data/search/')
   link(href='css/nsidc-search.css',rel='stylesheet',type='text/css')


### PR DESCRIPTION
The ACADIS fix had been implemented previously, but it needed to be
implemented for NSIDC Search as well.  Also added a "size" option to
the map initialization, as for some reason the new openlayers looks for
it instead of tileSize (not sure why this change wasn't needed for the
ACADIS fix).

Also made a slight update to the DEVELOPMENT documentation.

This is done for this ticket: https://www.pivotaltracker.com/story/show/105222730