### PR TITLE
Remove loading of nsidc background in ade search

### DIFF
--- a/src/sass/_config_ade.scss
+++ b/src/sass/_config_ade.scss
@@ -18,7 +18,7 @@ $search-criteria-add-on-border-left-color: #ddd;
 $search-criteria-box-shadow: 1px 2px 1px rgba(15, 38, 76, .4);
 $search-criteria-input-border: 1px solid #7a99aa;
 
-$header-spatial-container-width: 420px;
+$header-spatial-container-width: 440px;
 $header-spatial-container-margin: 15px 0 0 50px;
 
 // width for keyword input box and the auto-suggest drop-down

--- a/src/templates/ade-index.jade
+++ b/src/templates/ade-index.jade
@@ -1,5 +1,9 @@
 extends index-layout
 
+block nsidc-ssi
+    | <!--#include virtual="/ssi/secondary_styles.ssi" -->
+    | <!--#include virtual="/ssi/scripts.ssi" -->
+
 block body
     #container.container
       #main-content

--- a/src/templates/index-layout.jade
+++ b/src/templates/index-layout.jade
@@ -2,9 +2,9 @@ doctype
 html
   head
     title #{title}
-    | <!--#include virtual="/ssi/styles.ssi" -->
-    | <!--#include virtual="/ssi/secondary_styles.ssi" -->
-    | <!--#include virtual="/ssi/scripts.ssi" -->
+
+    block nsidc-ssi
+
     link(href='contrib/bootstrap/css/bootstrap.min.css',rel='stylesheet',type='text/css')
     link(href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.1/css/font-awesome.min.css',rel='stylesheet',type='text/css')
     link(href='https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.2/leaflet.css',rel='stylesheet',type='text/css')

--- a/src/templates/nsidc-index.jade
+++ b/src/templates/nsidc-index.jade
@@ -1,5 +1,10 @@
 extends index-layout
 
+block nsidc-ssi
+    | <!--#include virtual="/ssi/styles.ssi" -->
+    | <!--#include virtual="/ssi/secondary_styles.ssi" -->
+    | <!--#include virtual="/ssi/scripts.ssi" -->
+
 block body
     #wrapper
       | <!--#include virtual="/ssi/nsidc.ssi" -->


### PR DESCRIPTION
We were loading the background image and some styles from an ssi.

Removing that broke the spatial container's style, putting the
globe button down a row. We make the size of the spatial-container
larger to ensure it fits and stays where it should.