### PR TITLE
Skip over integration unittests, for now.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -177,7 +177,13 @@ grunt test:acceptance --url=http://localhost:8081 --project=ade_search
 Run the unit tests in [PhantomJS](http://phantomjs.org/) with `grunt
 jasmine`. Test code is located in `spec/`, written in
 [Jasmine 1.3](http://jasmine.github.io/1.3/introduction.html) along with
-[Sinon](http://sinonjs.org/).
+[Sinon](http://sinonjs.org/). 
+
+Note that running these tests locally may result in failure. If so, try running
+the unit tests in a browser (discussed below).  Make sure unit tests pass in the
+browser and in Travis CI before merging any code with master. Running headless
+unit tests have failed for local development starting after v1.11.0. Jasmine
+will probably need to be upgraded to v2.x before they work again.
 
 It can helpful for debugging purposes to run the unit tests in a browser. To do
 so, follow these steps:

--- a/puppet/ci.yaml
+++ b/puppet/ci.yaml
@@ -72,7 +72,7 @@ nsidc_jenkins::jobs:
       bundle exec rubocop
       grunt scsslint
       grunt jshint
-    trigger_job: "%{hiera('job_integration_unit_tests')}"
+    trigger_job: "%{hiera('job_integration_provision')}"
 
   "%{hiera('job_integration_unit_tests')}":
     workspace: /var/lib/jenkins/workspaces/%{hiera('project')}/integration


### PR DESCRIPTION
Unfortunately, unittests in integration are failing for an unknown
reason. This occurs locally as well, unless tests are run in the
browser. Unittests also work in travis ci, which is why we
are simply disabling this for now. The `fix-unittests` branch
is an attempt to update unittests to work with jasmine v2.x,
which should make unittests pass in travis and integration.
However, this work is not yet done and not a priority since
unittests still pass in browser + in travis ci.