### PR TITLE
Ade absolute urls

### DIFF
--- a/src/conf/ade/appConfig-integration.js
+++ b/src/conf/ade/appConfig-integration.js
@@ -28,7 +28,7 @@ define([],
         crazyEggMetrics: false,
 
         // websockets
-        wsService: '/api/notification',
+        wsService: '//integration.nsidc.org/api/notification',
         wsHostApp: 'ADE',
 
         // results header

--- a/src/conf/ade/appConfig-integration.js
+++ b/src/conf/ade/appConfig-integration.js
@@ -2,7 +2,7 @@ define([],
   function () {
 
     var openSearchOptions = {
-      osdd: '/api/dataset/2/OpenSearchDescription',
+      osdd: '//integration.nsdic.org/api/dataset/2/OpenSearchDescription',
       osSource: 'ADE',
       osStartIndex: 0,
       osItemsPerPage: 25,

--- a/src/conf/ade/appConfig-production.js
+++ b/src/conf/ade/appConfig-production.js
@@ -2,7 +2,7 @@ define([],
   function () {
 
     var openSearchOptions = {
-      osdd: '/api/dataset/2/OpenSearchDescription',
+      osdd: '//nsidc.org/api/dataset/2/OpenSearchDescription',
       osSource: 'ADE',
       osStartIndex: 0,
       osItemsPerPage: 25,

--- a/src/conf/ade/appConfig-production.js
+++ b/src/conf/ade/appConfig-production.js
@@ -28,7 +28,7 @@ define([],
         crazyEggMetrics: true,
 
         // websockets
-        wsService: '/api/notification',
+        wsService: '//nsidc.org/api/notification',
         wsHostApp: 'ADE',
 
         // results header

--- a/src/conf/ade/appConfig-qa.js
+++ b/src/conf/ade/appConfig-qa.js
@@ -28,7 +28,7 @@ define([],
         crazyEggMetrics: false,
 
         // websockets
-        wsService: '/api/notification',
+        wsService: '//qa.nsidc.org/api/notification',
         wsHostApp: 'ADE',
 
         // results header

--- a/src/conf/ade/appConfig-qa.js
+++ b/src/conf/ade/appConfig-qa.js
@@ -2,7 +2,7 @@ define([],
   function () {
 
     var openSearchOptions = {
-      osdd: '/api/dataset/2/OpenSearchDescription',
+      osdd: '//qa.nsidc.org/api/dataset/2/OpenSearchDescription',
       osSource: 'ADE',
       osStartIndex: 0,
       osItemsPerPage: 25,


### PR DESCRIPTION
ADE search will be hosted at the new NSIDC labs domain.  Some references now need the absolute path to the correct environment on the nsidc.org domain.