### PR TITLE
Change the project name vagrant uses for ade search

### DIFF
--- a/vagrant-nsidc.ade_search.yaml
+++ b/vagrant-nsidc.ade_search.yaml
@@ -1,4 +1,4 @@
-project: ade_search
+project: arctic-data-explorer
 gitrepo: git@github.com:nsidc/search-interface.git
 
 puppet:


### PR DESCRIPTION
From ade_search -> arctic-data-explorer. This is required in order
to properly set up the new labs location at:
arctic-data-explorer.labs.nsidc.org