### PR TITLE
Enabling SSH on server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Adding HTTPS support to nginx server
+
 ## 2.0.1 (2019-07-11)
 
 - Fixing acceptance tests

--- a/puppet/site.pp
+++ b/puppet/site.pp
@@ -94,8 +94,15 @@ if ($environment == 'integration') or ($environment == 'qa') or ($environment ==
     gzip => 'off'
   }
 
+  exec { 'make_cert':
+    path => ['/bin', '/usr/bin'],
+    command => 'mkdir -p /etc/nginx/ssl && openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt -subj "/CN=nsidc"'
+  } ->
   nginx::resource::vhost { 'search' :
-    www_root => $application_root
+    www_root => $application_root,
+    ssl => true,
+    ssl_cert => '/etc/nginx/ssl/nginx.crt',
+    ssl_key => '/etc/nginx/ssl/nginx.key',
   }
 
   nginx::resource::location { '/acadis/search' :
@@ -105,7 +112,8 @@ if ($environment == 'integration') or ($environment == 'qa') or ($environment ==
 
   nginx::resource::location { '/data/search' :
     location_alias => $application_root,
-    vhost => 'search'
+    vhost => 'search',
+    ssl => true
   }
 
   # remove default nginx config

--- a/src/scripts/lib/spatial_selection_map/SpatialSelectionUtilities.js
+++ b/src/scripts/lib/spatial_selection_map/SpatialSelectionUtilities.js
@@ -22,10 +22,10 @@ define([], function () {
   return {
 
     // the URL to the NSIDC map server and tile cache server
-    //dev MAP_SERVER = 'http://devsnowdev.nsidc.org/api/ogc/';
-    //test MAP_SERVER = 'http://testsnowtest.nsidc.org/api/ogc/';
-    //prod MAP_SERVER = 'http://nsidc.org/api/ogc/';
-    MAP_SERVER : 'http://nsidc.org/api/ogc/',
+    //dev MAP_SERVER = 'https://integration.nsidc.org/api/ogc/';
+    //test MAP_SERVER = 'https://staging.nsidc.org/api/ogc/';
+    //prod MAP_SERVER = 'https://nsidc.org/api/ogc/';
+    MAP_SERVER : 'https://nsidc.org/api/ogc/',
 
     // the string used to identify the NSIDC map server WMS layer
     WMS_LAYER_NAME : 'NSIDC WMS',

--- a/src/templates/nsidc-index.jade
+++ b/src/templates/nsidc-index.jade
@@ -16,5 +16,5 @@ block body
         #view-template-script-container
 
 block project-css
-  link(rel='canonical',href='http://www.nsidc.org/data/search/')
+  link(rel='canonical',href='https://www.nsidc.org/data/search/')
   link(href='css/nsidc-search.css',rel='stylesheet',type='text/css')


### PR DESCRIPTION
This code change allows https requests to be used on the VM server.  Note that it does not force HTTPS (HTTP requests are still allowed), and there's still an issue where a request to https://<server>.nsidc.org/data/search forwards to http://<server>.nsidc.org/data/search/ that I have not been able to solve.  We may be able to fix that with proxy rules.