### PR TITLE
Updating gems for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 2.1.0 (2019-08-23)
+## Unreleased
 
+- Updating RubyGems to latest version per security announcement
+
+## 2.1.0 (2019-08-23)
 
 - Adding HTTPS support to nginx server
 

--- a/puppet/site.pp
+++ b/puppet/site.pp
@@ -22,6 +22,10 @@ if $environment == 'ci' {
     path => ['/usr/bin'],
     require => Package['ruby-switch']
   } ->
+  exec { 'gem-update':
+    command => 'gem update --system',
+    path => ['/usr/bin']
+  } ->
   exec { 'install bundler':
     command => 'sudo gem install bundler -v 1.17.1',
     path => '/usr/bin'


### PR DESCRIPTION
Only the CI machine seems to actually use the gems; the individual VMs don't, they just run grunt/Javascript stuff.