### PR TITLE
SRCH-119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Remove `engines` section from `package.json` as a workaround for older Drupal
+  environment.
+
 ## v4.1.0 (2023-08-03)
 
 - Bump Javascript dependencies to latest possible versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nsidc/search-interface",
-  "version": "4.1.0",
+  "version": "4.1.1-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nsidc/search-interface",
-      "version": "4.1.0",
+      "version": "4.1.1-rc.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "backbone": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nsidc/search-interface",
-  "version": "4.1.1-rc.0",
+  "version": "4.1.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nsidc/search-interface",
-      "version": "4.1.1-rc.0",
+      "version": "4.1.1-rc.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "backbone": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsidc/search-interface",
   "description": "NSIDC data search interface",
-  "version": "4.1.0",
+  "version": "4.1.1-rc.0",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nsidc/search-interface",
   "description": "NSIDC data search interface",
-  "version": "4.1.1-rc.0",
+  "version": "4.1.1-rc.1",
   "license": "GPL-3.0-only",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
     "LICENSE",
     "README.md"
   ],
-  "engines": {
-    "node": "^20.5.0",
-    "npm": "^9.8.0"
-  },
   "type": "module",
   "browser": "./dist/index.bundle.js",
   "scripts": {


### PR DESCRIPTION
Remove the explicit `node` and `npm` version requirements from `package.json` to work around the fact that NSIDC Drupal instances are using older versions of `node` and `npm`.